### PR TITLE
Add authAddress to the validation signature

### DIFF
--- a/contracts/LinkedAddress.sol
+++ b/contracts/LinkedAddress.sol
@@ -35,6 +35,7 @@ library LinkedAddress {
      */
     function validate(
         address ensRegistry,
+        address authAddress,
         bytes calldata authENSLabel,
         address mainAddress,
         string[] calldata mainENSParts
@@ -70,7 +71,7 @@ library LinkedAddress {
         bytes32 authNameHash = _computeNamehash(mainNameHash, string(authENSLabel));
         address authResolver = ENS(ensRegistry).resolver(authNameHash);
         require(authResolver != address(0), "Auth ENS not registed");
-        require(msg.sender == Resolver(authResolver).addr(authNameHash), "Not authenticated");
+        require(authAddress == Resolver(authResolver).addr(authNameHash), "Not authenticated");
 
         // Check that the subdomain name has the correct format auth[0-9]*.
         bytes4 authPart = bytes4(authENSLabel[:4]);

--- a/contracts/mocks/MockContract.sol
+++ b/contracts/mocks/MockContract.sol
@@ -15,6 +15,13 @@ contract MockContract {
         address mainAddress,
         string[] calldata mainENSParts
     ) external returns (bool) {
-        return LinkedAddress.validate(ensRegistry, authENSLabel, mainAddress, mainENSParts);
+        return
+            LinkedAddress.validate(
+                ensRegistry,
+                msg.sender,
+                authENSLabel,
+                mainAddress,
+                mainENSParts
+            );
     }
 }


### PR DESCRIPTION
This adds `authAddress` as a parameter to the validation library function.

This makes it more obvious where `authAddress` comes from (implicitly assumed to be `msg.sender` before) and provides more flexibility by leaving it up to the caller to decide which address should be checked.

Sorry that I also added this in the previous PRs without explanation. 